### PR TITLE
controllers/csr: pass full certificate chain as part of certificate

### DIFF
--- a/controllers/csr_controller.go
+++ b/controllers/csr_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"fmt"
@@ -45,18 +46,20 @@ const (
 // CSRReconciler reconciles a CSR object
 type CSRReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Log         logr.Logger
-	KeyProvider keyprovider.KeyProvider
-	mutex       sync.Mutex
+	Scheme        *runtime.Scheme
+	Log           logr.Logger
+	KeyProvider   keyprovider.KeyProvider
+	mutex         sync.Mutex
+	fullCertChain bool
 }
 
-func NewCSRReconciler(c client.Client, scheme *runtime.Scheme, keyProvider keyprovider.KeyProvider) *CSRReconciler {
+func NewCSRReconciler(c client.Client, scheme *runtime.Scheme, keyProvider keyprovider.KeyProvider, fullCertChain bool) *CSRReconciler {
 	return &CSRReconciler{
-		Log:         ctrl.Log.WithName("controllers").WithName("CSR"),
-		Client:      c,
-		Scheme:      scheme,
-		KeyProvider: keyProvider,
+		Log:           ctrl.Log.WithName("controllers").WithName("CSR"),
+		Client:        c,
+		Scheme:        scheme,
+		KeyProvider:   keyProvider,
+		fullCertChain: fullCertChain,
 	}
 }
 
@@ -165,7 +168,20 @@ func (r *CSRReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	patch := client.MergeFrom(csr.DeepCopy())
-	csr.Status.Certificate = tlsutil.EncodeCert(cert)
+	if r.fullCertChain {
+		l.Info("Preparing full certificate chain")
+		// NOTE(avalluri): This is a temporary solution to make it work with Istio v1.12,
+		// Where it expects the full certChain along with the root certificate.
+		// But according to https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2
+		// self-signed root certificate should not include the certificat chain.
+		certChain, err := encodeX509Chain([]*x509.Certificate{cert, s.Certificate()})
+		if err != nil {
+			return retry, fmt.Errorf("error preparing cert chain: %v", err)
+		}
+		csr.Status.Certificate = certChain
+	} else {
+		csr.Status.Certificate = tlsutil.EncodeCert(cert)
+	}
 	if err := r.Client.Status().Patch(ctx, &csr, patch); err != nil {
 		return retry, fmt.Errorf("error patching CSR: %v", err)
 	}
@@ -264,4 +280,14 @@ func k8sKeyUsagesToX509KeyUsages(usages []crtv1.KeyUsage) (x509.KeyUsage, []x509
 	}
 
 	return keyUsage, extUsage, nil
+}
+
+func encodeX509Chain(certs []*x509.Certificate) ([]byte, error) {
+	caPem := bytes.NewBuffer([]byte{})
+	//caPem := []byte{}
+	for _, cert := range certs {
+		caPem.Write(tlsutil.EncodeCert(cert)[:])
+	}
+
+	return caPem.Bytes(), nil
 }

--- a/controllers/csr_controller_test.go
+++ b/controllers/csr_controller_test.go
@@ -108,7 +108,7 @@ var _ = Describe("CSR controller", func() {
 
 		fakeKeyProvider = testutils.NewKeyProvider(signers)
 
-		controller = controllers.NewCSRReconciler(k8sClient, scheme, fakeKeyProvider)
+		controller = controllers.NewCSRReconciler(k8sClient, scheme, fakeKeyProvider, false)
 	})
 
 	AfterEach(func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	HealthProbeAddress string
 	LeaderElection     bool
 	CertManagerIssuer  bool
+	CSRFullCertChain   bool
 
 	HSMTokenLabel string
 	HSMUserPin    string

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 	flag.StringVar(&cfg.HSMTokenLabel, "token-label", "SgxOperator", "PKCS11 label to use for the operator token.")
 	flag.StringVar(&cfg.HSMUserPin, "user-pin", "", "PKCS11 token user pin.")
 	flag.StringVar(&cfg.HSMSoPin, "so-pin", "", "PKCS11 token so/admin pin.")
+	flag.BoolVar(&cfg.CSRFullCertChain, "csr-full-cert-chain", false, "Return full certificate chain in Kubernetes CSR certificate.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -126,7 +127,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "QuoteAttestation")
 		os.Exit(1)
 	}
-	if err = controllers.NewCSRReconciler(mgr.GetClient(), mgr.GetScheme(), sgxctx).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewCSRReconciler(mgr.GetClient(), mgr.GetScheme(), sgxctx, cfg.CSRFullCertChain).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CSR")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Add an command-line option to configure the csr controller such that it
fills the full certificate chain (signed cert + ca-cert) in
`status.certificate` on a successful certificate signing.

The full cert chain with root certificate is expected by Istio v1.12,
otherwise this feature should not be enabled.