### PR TITLE
Few enhancements

### DIFF
--- a/controllers/quoteattestation_controller_test.go
+++ b/controllers/quoteattestation_controller_test.go
@@ -504,7 +504,7 @@ var _ = Describe("QuoteAttestaion controller", func() {
 
 		s, err := fakeKeyProvider.GetSignerForName(testSigner)
 		Expect(err).ShouldNot(HaveOccurred(), "get signer")
-		s.SetPending(qaKey.Name)
+		s.SetPending(qaKey.Name, qaKey.Namespace)
 		// 6. Pass corrupted Certificate
 		err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(secret), secret)
 		Expect(err).ShouldNot(HaveOccurred(), "failed fetch secret")

--- a/internal/sgx/sgx.go
+++ b/internal/sgx/sgx.go
@@ -583,11 +583,7 @@ func (ctx *SgxContext) initiateQuoteAttestation(pending []*signer.Signer) (err e
 	}
 	ctx.log.Info("Initiating quote attestation", "name", name, "forSigners", pending)
 	err = k8sutil.QuoteAttestationDeliver(
-<<<<<<< HEAD
-		context.TODO(), ctx.k8sClient, name, "", tcsapi.RequestTypeKeyProvisioning, names, ctx.ctkQuote, pubKey, ctx.cfg.HSMTokenLabel)
-=======
-		context.TODO(), ctx.k8sClient, name, ns, names, ctx.ctkQuote, pubKey, ctx.cfg.HSMTokenLabel)
->>>>>>> 4669c89... controllers/qa: create QA object in issuers name
+		context.TODO(), ctx.k8sClient, name, ns, tcsapi.RequestTypeKeyProvisioning, names, ctx.ctkQuote, pubKey, ctx.cfg.HSMTokenLabel)
 	if err != nil {
 		ctx.log.Info("ERROR: Failed to creat QA object")
 		return err


### PR DESCRIPTION
- Made Issuer's secret owned by it by adding owner refer. So its life is linked with the Issuers lifetime.
- Create the QuoteAttestation object in the same namespace as the associated Issuer where appropriate.
- Set finalizer on objects created by the issuer, so that they are protected from unexpected deletes.