### PR TITLE
QuoteAttestation: Add new field for request type

### DIFF
--- a/api/v1alpha1/quoteattestation_types.go
+++ b/api/v1alpha1/quoteattestation_types.go
@@ -57,8 +57,26 @@ const (
 	ECDSAQuoteVersion3 = "ECDSA Quote 3"
 )
 
+// QuoteAttestationRequestType type definition for representing
+// the type of attestation request
+type QuoteAttestationRequestType string
+
+const (
+	// RequestTypeQuoteAttestation represents the type of request
+	// is for only quote verification
+	RequestTypeQuoteAttestation = "QuoteAttestation"
+	// RequestTypeKeyProvisioning represents the type of request
+	// is for CA key provisioning where quote verification is a
+	// pre-requisite
+	RequestTypeKeyProvisioning = "KeyProvisioning"
+)
+
 // QuoteAttestationSpec defines the desired state of QuoteAttestation
 type QuoteAttestationSpec struct {
+	// Type represents the type of the request, one of "QuoteAttestation", "KeyProvisioning".
+	// +kubebuilder:validation:Enum=QuoteAttestation;KeyProvisioning
+	// +kubebuilder:validation:default=KeyProvisioning
+	Type QuoteAttestationRequestType `json:"type"`
 	// Quote to be verified, base64-encoded.
 	// +kubebuilder:listType=atomic
 	Quote []byte `json:"quote"`

--- a/config/crd/tcs.intel.com_quoteattestations.yaml
+++ b/config/crd/tcs.intel.com_quoteattestations.yaml
@@ -60,11 +60,19 @@ spec:
                 items:
                   type: string
                 type: array
+              type:
+                description: Type represents the type of the request, one of "QuoteAttestation",
+                  "KeyProvisioning".
+                enum:
+                - QuoteAttestation
+                - KeyProvisioning
+                type: string
             required:
             - publicKey
             - quote
             - serviceId
             - signerNames
+            - type
             type: object
           status:
             description: QuoteAttestationStatus defines the observed state of QuoteAttestation

--- a/controllers/quoteattestation_controller_test.go
+++ b/controllers/quoteattestation_controller_test.go
@@ -564,6 +564,7 @@ func newQuoteAttestation(name, namespace, signerName string) *tcsapi.QuoteAttest
 			Namespace: namespace,
 		},
 		Spec: tcsapi.QuoteAttestationSpec{
+			Type:         tcsapi.RequestTypeKeyProvisioning,
 			Quote:        quote,
 			PublicKey:    pubkey,
 			QuoteVersion: tcsapi.ECDSAQuoteVersion3,

--- a/internal/k8sutil/k8sutil.go
+++ b/internal/k8sutil/k8sutil.go
@@ -94,6 +94,7 @@ func QuoteAttestationDeliver(
 	ctx context.Context,
 	c client.Client,
 	instanceName, namespace string,
+	requestType tcsapi.QuoteAttestationRequestType,
 	signerNames []string,
 	quote []byte,
 	quotePubKey interface{},
@@ -116,6 +117,7 @@ func QuoteAttestationDeliver(
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.QuoteAttestationSpec{
+			Type:         requestType,
 			Quote:        []byte(encQuote),
 			QuoteVersion: tcsapi.ECDSAQuoteVersion3,
 			SignerNames:  signerNames,

--- a/internal/sgx/sgx.go
+++ b/internal/sgx/sgx.go
@@ -55,6 +55,7 @@ import (
 
 	"github.com/ThalesIgnite/crypto11"
 	"github.com/go-logr/logr"
+	tcsapi "github.com/intel/trusted-certificate-issuer/api/v1alpha1"
 	"github.com/intel/trusted-certificate-issuer/internal/config"
 	"github.com/intel/trusted-certificate-issuer/internal/k8sutil"
 	"github.com/intel/trusted-certificate-issuer/internal/keyprovider"
@@ -581,7 +582,7 @@ func (ctx *SgxContext) initiateQuoteAttestation(pending []*signer.Signer) (err e
 	}
 	ctx.log.Info("Initiating quote attestation", "name", name, "forSigners", pending)
 	err = k8sutil.QuoteAttestationDeliver(
-		context.TODO(), ctx.k8sClient, name, "", names, ctx.ctkQuote, pubKey, ctx.cfg.HSMTokenLabel)
+		context.TODO(), ctx.k8sClient, name, "", tcsapi.RequestTypeKeyProvisioning, names, ctx.ctkQuote, pubKey, ctx.cfg.HSMTokenLabel)
 	if err != nil {
 		ctx.log.Info("ERROR: Failed to creat QA object")
 		return err


### PR DESCRIPTION
New field 'type' is added to hold the type of attestation request. This is to support initiating the QuoteAttestation from CSR only quote validation. In this case, the quote attestation controller does not proceed with key wrapping.