### PR TITLE
Dockerfile: lock CTK to a fixed version (commit-id)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN wget https://download.01.org/intel-sgx/sgx-linux/2.15/distro/ubuntu20.04-ser
   && rm $SGX_SDK_INSTALLER \
   && ls -l /opt/intel/
 
+# Tag/commit-id/branch to use for bulding CTK
+ARG CTK_TAG="master"
+
 # Intel crypto-api-toolkit prerequisites
 #https://github.com/intel/crypto-api-toolkit#software-requirements
 RUN set -x && apt-get update \
@@ -87,6 +90,7 @@ RUN set -x && apt-get update \
   && apt-get clean \
   && git clone https://github.com/intel/crypto-api-toolkit.git \
   && cd /opt/intel/crypto-api-toolkit \
+  && git checkout ${CTK_TAG} -b v${CTK_TAG} \
   # disable building tests
   && sed -i -e 's;test;;g' ./src/Makefile.am \
   # disable enclave signing inside CTK

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,15 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# Latest CTK commit id as of 31.03.2022 which includes
+# mitigation for key export vulnerability.
+#
+# Keep update this to include the latest CTK code changes.
+CTK_TAG ?= 91ee4968b7b97996f8c466a3ebbdce41168118e3
+
 # additional arguments to pass to 'docker build'
 BUILD_ARGS ?=
+BUILD_ARGS := $(BUILD_ARGS) --build-arg CTK_TAG=${CTK_TAG}
 # Adjust this argument and accodingly the 'enclave-config/sign-enclave.sh'
 # script in CI build system to reflect with the right private key
 # and/or signing with external tool.


### PR DESCRIPTION
CTK_TAG make variable can be set to a specific CTK source commit so
that, this commit id is used to fetch and build the CTK while image
creation.