### PR TITLE
internal/sgx: do not share quote between multiple issuers

### DIFF
--- a/controllers/issuer_controller.go
+++ b/controllers/issuer_controller.go
@@ -128,7 +128,7 @@ func (r *IssuerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 			if err := r.Get(ctx, qaReq, qa); err != nil {
 				if apierrors.IsNotFound(err) {
 					// means no quoteattestation object, create new one
-					quote, publickey, err := r.KeyProvider.GetQuoteAndPublicKey()
+					quote, publickey, err := r.KeyProvider.GetQuoteAndPublicKey(signerName)
 					if err != nil {
 						log.Info("Error preparing SGX quote", "error", err)
 						issuerStatus.SetCondition(tcsapi.IssuerConditionReady, v1.ConditionFalse, "Reconcile", fmt.Sprintf("failed to get sgx quote: %v", err.Error()))

--- a/internal/keyprovider/keyprovider.go
+++ b/internal/keyprovider/keyprovider.go
@@ -47,5 +47,5 @@ type KeyProvider interface {
 	ProvisionSigner(signerName string, encryptedKey []byte, cert *x509.Certificate) (*signer.Signer, error)
 
 	// GetQuoteAndPublicKey returns SGX quote and the publickey used for generating the quote
-	GetQuoteAndPublicKey() ([]byte, interface{}, error)
+	GetQuoteAndPublicKey(signerName string) ([]byte, interface{}, error)
 }

--- a/test/utils/ca-provide.go
+++ b/test/utils/ca-provide.go
@@ -107,7 +107,7 @@ func (kp *fakeKeyProvider) ProvisionSigner(signerName string, base64Key []byte, 
 	return s, nil
 }
 
-func (kp *fakeKeyProvider) GetQuoteAndPublicKey() ([]byte, interface{}, error) {
+func (kp *fakeKeyProvider) GetQuoteAndPublicKey(string) ([]byte, interface{}, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
CTK destroys the quote public key and the wrapped key after successful unwrap. Hence the same quote cannot be used for unwrapping the other keys. So, we have to use singer specific quote.