### PR TITLE
config: increase pod resource limits

### DIFF
--- a/charts/templates/tcs_issuer.yaml
+++ b/charts/templates/tcs_issuer.yaml
@@ -340,8 +340,8 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 100Mi
             sgx.intel.com/enclave: 1
             sgx.intel.com/epc: 512Ki
           requests:

--- a/config/manager/tcs_issuer.yaml
+++ b/config/manager/tcs_issuer.yaml
@@ -65,8 +65,8 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 100Mi
             sgx.intel.com/enclave: 1
             sgx.intel.com/epc: 512Ki
           requests:

--- a/deployment/tcs_issuer.yaml
+++ b/deployment/tcs_issuer.yaml
@@ -351,8 +351,8 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 100Mi
             sgx.intel.com/enclave: 1
             sgx.intel.com/epc: 512Ki
           requests:


### PR DESCRIPTION
Observed that the TCS pod gets killed by OOM with the provided memory
limits. Hence improve the default limits.