### PR TITLE
Use random nonce with timestamp for quote generation

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,3 +8,4 @@ image:
 controllerExtraArgs: {}
 #controllerExtraArgs: |-
 #  - --csr-full-cert-chain=true
+#  - --use-random-nonce=true

--- a/config/manager/tcs_issuer.yaml
+++ b/config/manager/tcs_issuer.yaml
@@ -45,6 +45,7 @@ spec:
         - --health-probe-bind-address=:8083
         - --user-pin=$USER_PIN
         - --so-pin=$SO_PIN
+        - --use-random-nonce=true # Disable this if using KMRA version < 2.2
         image: tcs-issuer
         imagePullPolicy: Always
         name: tcs-issuer

--- a/deployment/tcs_issuer.yaml
+++ b/deployment/tcs_issuer.yaml
@@ -320,6 +320,7 @@ spec:
         - --health-probe-bind-address=:8083
         - --user-pin=$USER_PIN
         - --so-pin=$SO_PIN
+        - --use-random-nonce=true
         command:
         - /tcs-issuer
         env:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	LeaderElection     bool
 	CertManagerIssuer  bool
 	CSRFullCertChain   bool
+	RandomNonce        bool
 
 	HSMTokenLabel string
 	HSMUserPin    string

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 	flag.StringVar(&cfg.HSMUserPin, "user-pin", "", "PKCS11 token user pin.")
 	flag.StringVar(&cfg.HSMSoPin, "so-pin", "", "PKCS11 token so/admin pin.")
 	flag.BoolVar(&cfg.CSRFullCertChain, "csr-full-cert-chain", false, "Return full certificate chain in Kubernetes CSR certificate.")
+	flag.BoolVar(&cfg.RandomNonce, "use-random-nonce", true, "Use random nonce for SGX quote generation. Needed for KMRA version >= v2.2.")
 
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
This is to support the latest (V2.2) KMRA changes.