### PR TITLE
Makefile: new target for preparing the release branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ deploy-manifests: manifests kustomize
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+VERSION ?=
+release-branch:
+ifeq ("$(VERSION)", "")
+	$(error "Set release version using VERSION make variable. Example: `make release VERSION=0.1.0` ")
+endif
+	./hack/prepare-release-branch.sh --version $(VERSION)
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.

--- a/hack/prepare-release-branch.sh
+++ b/hack/prepare-release-branch.sh
@@ -1,0 +1,71 @@
+# !/bin/bash
+#
+# Script runs below steps to prepare a new release branch:
+# - Fetch the latest main branch from remote origin (it must point to github.com/intel/trusted-certificate-issuer).
+# - Create a new branch with current main HEAD.
+# - Run needed make targets to generate manifests with the new version.
+# - Modify helm charts with new version.
+# - Commit the changes.
+# - And return back to the previous branch.
+#
+set -o pipefail
+set -o errexit
+
+SOURCE=$(dirname "$(readlink -f "$0")")
+REPO_ROOT=$(dirname $SOURCE)
+
+VERSION=
+pwd=$(pwd)
+current_branch=$(git branch --show-current)
+release_branch=
+
+function Usage {
+    echo "Usage:"
+    echo "   $0 --version <semver version>"
+}
+
+for opt in $@
+do
+    case "$opt" in
+    --version)
+        shift ; VERSION=$1 ;;
+    -h | --help)
+        Usage ; exit ;;
+    -*) shift ; echo "Unrecognized option $opt" ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: No release version set."
+    Usage
+    exit
+fi
+
+function Cleanup {
+    git checkout $current_branch
+    if [ ! -z "$release_branch" ] ; then
+        git branch -D "$release_branch"
+    fi
+    cd "$pwd"
+}
+trap Cleanup EXIT
+
+echo "Using release VERSION=$VERSION"
+
+release_branch="release-v$VERSION"
+
+cd "$REPO_ROOT"
+git fetch origin
+git checkout -b $release_branch $(git show --oneline origin/main | cut -f1 -d ' ')
+make generate deploy-manifests REGISTRY="intel" IMG_TAG=$VERSION
+sed -i -e "s;\(.*version: \).*;\1$VERSION;g" -e 's;\(.*appVersion: \).*;\1"'$VERSION'";g' ./charts/Chart.yaml
+sed -i "s;\(.*tag: \).*;\1$VERSION;g" ./charts/values.yaml
+git checkout ./config/manager/kustomization.yaml
+git add ./deployment ./charts && git commit -m "Release v$VERSION"
+# Unset release_branch so that Cleanup does not delete the branch.
+release_branch=""
+
+echo ========================
+echo "Created new release branch $release_branch. Review and run 'git push origin $release_branch'."
+echo =======================
+


### PR DESCRIPTION
Added a new make target named 'release-branch' which prepares a new branch.
It makes sure that all the deployment files point to the release image.

A new release branch is checked out from the current 'main'. The release branch would be added with one additional commit with the release-specific change like modifying the deployment manifests to point to the release image, and helm chart with the release number. The new release branch is supposed to be tagged for the release.