### PR TITLE
controller/issuer: make sure the signer is loaded from token

### DIFF
--- a/internal/sgx/sgx.go
+++ b/internal/sgx/sgx.go
@@ -172,17 +172,6 @@ func (ctx *SgxContext) GetQuoteAndPublicKey(signerName string) ([]byte, interfac
 	return ctx.ensureQuote(signerName)
 }
 
-func (ctx *SgxContext) GetPendingSigners() []string {
-	if ctx == nil {
-		return []string{}
-	}
-	signers := []string{}
-	for _, signer := range ctx.signers.PendingSigners() {
-		signers = append(signers, signer.Name())
-	}
-	return signers
-}
-
 func (ctx *SgxContext) SignerNames() []string {
 	if ctx == nil {
 		return []string{}


### PR DESCRIPTION
Make sure that the signer info is loaded from the persistnat token. Otherwise, in case of Pod restart, the existing signers are not loaded and hence not ready for sining the new CSR requests.