### PR TITLE
Validate SGX Quote if provided inside CSR

### DIFF
--- a/controllers/certificate_request_controller.go
+++ b/controllers/certificate_request_controller.go
@@ -199,7 +199,7 @@ func (r *CertificateRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		l.Info("Signing ...")
-		cert, err := ca.Sign(cr.Spec.Request, keyUsage, extKeyUsage)
+		cert, err := ca.Sign(cr.Spec.Request, keyUsage, extKeyUsage, nil)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to sign CertificateRequest: %v", err)
 		}

--- a/internal/self-ca/self-ca.go
+++ b/internal/self-ca/self-ca.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 
 	"github.com/intel/trusted-certificate-issuer/internal/tlsutil"
 	cmpki "github.com/jetstack/cert-manager/pkg/util/pki"
@@ -91,7 +92,7 @@ func (ca *CA) EncodedCertificate() []byte {
 	return tlsutil.EncodeCert(ca.cert)
 }
 
-func (ca *CA) Sign(csrPEM []byte, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage) (*x509.Certificate, error) {
+func (ca *CA) Sign(csrPEM []byte, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage, extensions []pkix.Extension) (*x509.Certificate, error) {
 	if ca == nil {
 		return nil, fmt.Errorf("nil CA")
 	}
@@ -103,6 +104,7 @@ func (ca *CA) Sign(csrPEM []byte, keyUsage x509.KeyUsage, extKeyUsage []x509.Ext
 	}
 	tmpl.Issuer = ca.cert.Issuer
 	tmpl.Version = tls.VersionTLS12
+	tmpl.ExtraExtensions = extensions
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, tmpl.PublicKey, ca.prKey)
 	*tmpl = x509.Certificate{}

--- a/internal/self-ca/self-ca_test.go
+++ b/internal/self-ca/self-ca_test.go
@@ -98,7 +98,7 @@ func TestSelfCA(t *testing.T) {
 		csrBytes, err := testutils.NewCertificateRequest(key, pkix.Name{CommonName: "client-service"})
 		require.NoError(t, err, "create CSR")
 
-		_, err = ca.Sign(testutils.EncodeCSR(csrBytes), x509.KeyUsageCRLSign, nil)
+		_, err = ca.Sign(testutils.EncodeCSR(csrBytes), x509.KeyUsageCRLSign, nil, nil)
 		require.NoError(t, err, "sign client certificate")
 	})
 }

--- a/internal/sgx/sgx.go
+++ b/internal/sgx/sgx.go
@@ -630,7 +630,7 @@ func (ctx *SgxContext) generateQuote(pubKey pkcs11.ObjectHandle) ([]byte, *rsa.P
 		return nil, nil, fmt.Errorf("quote generation failure: invalid quote")
 	}
 
-	publicKey, err := parseQuotePublickey(quotePubKey[:offset])
+	publicKey, err := ParseQuotePublickey(quotePubKey[:offset])
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse quote public key: %v", err)
 	}
@@ -638,12 +638,12 @@ func (ctx *SgxContext) generateQuote(pubKey pkcs11.ObjectHandle) ([]byte, *rsa.P
 	return quotePubKey[offset:], publicKey, nil
 }
 
-// parseQuotePublickey reconstruct the rsa public key
+// ParseQuotePublickey reconstruct the rsa public key
 // from received bytes, received bytes structure like this:
 // pubkey_params   |    ulExponentLen   |    ulModulusLen
 // need to slice ulExponentLen and ulModulusLen to
 // reconstruct pubkey according to the size of each item
-func parseQuotePublickey(pubkey []byte) (*rsa.PublicKey, error) {
+func ParseQuotePublickey(pubkey []byte) (*rsa.PublicKey, error) {
 	paramsSize := uint64(C.rsa_key_params_size())
 	exponentLen := uint64(C.ulExponentLen_offset(*(*C.CK_BYTE_PTR)(unsafe.Pointer(&pubkey))))
 	modulusOffset := paramsSize + exponentLen


### PR DESCRIPTION
This is to validate the CSRs received from Istio where the mutual TLS private key is stored in the SGX Enclave. In that case we sign the request only it is coming from a valid enclave.