### PR TITLE
Add docker-build proxy setting example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 # Add 01.org to apt for SGX packages
 # hadolint ignore=DL4006
   && echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" >> /etc/apt/sources.list.d/intel-sgx.list \
-  && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
+  && wget -O - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
 # Install SGX PSW
   && apt-get update \
   && apt-get install --no-install-recommends -y \
@@ -150,7 +150,7 @@ ARG DCAP_VERSION
 RUN apt-get update \
   && apt-get install -y wget gnupg \
   && echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" >> /etc/apt/sources.list.d/intel-sgx.list \
-  && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
+  && wget -O - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
   && sed -i '/deb-src/s/^# //' /etc/apt/sources.list \
   && apt-get update \
   && apt-get remove -y wget gnupg && apt-get autoremove -y \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ $ export REGISTRY="localhost:5000" # docker registry to push the container image
 $ make docker-build
 $ make docker-push
 ```
-
+> **NOTE**: If you operate behind a corporate proxy, proxy settings can be passed in like \
+```make docker-build BUILD_ARGS="--build-arg http_proxy=someproxy --build-arg https_proxy=someproxy --build-arg no_proxy=some_list"```
 3. Deploy custom resource definitions (CRDs)
 
 ```sh


### PR DESCRIPTION
1. Add docker-build proxy setting in document.
2. remove `-q` option of `wget`, which makes it silent and hard to figure out what happens when there is network issue.