### PR TITLE
add codegen comments quoteattestation API

### DIFF
--- a/api/v1alpha1/quoteattestation_types.go
+++ b/api/v1alpha1/quoteattestation_types.go
@@ -130,6 +130,10 @@ type QuoteAttestationStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
 // QuoteAttestation is the Schema for the quoteattestations API
 type QuoteAttestation struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -140,6 +144,8 @@ type QuoteAttestation struct {
 }
 
 //+kubebuilder:object:root=true
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // QuoteAttestationList contains a list of QuoteAttestation
 type QuoteAttestationList struct {

--- a/api/v1alpha2/quoteattestation_types.go
+++ b/api/v1alpha2/quoteattestation_types.go
@@ -136,6 +136,11 @@ type QuoteAttestationStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
 // QuoteAttestation is the Schema for the quote attestation API
 type QuoteAttestation struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -146,6 +151,8 @@ type QuoteAttestation struct {
 }
 
 //+kubebuilder:object:root=true
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // QuoteAttestationList contains a list of QuoteAttestation
 type QuoteAttestationList struct {


### PR DESCRIPTION
Codegen tools like deepcopy-gen and client-gen are used to generate client API in sds server, 
and we also would like to reuse quoteattestation API of TCS issuer,
so there are some codegen comments needed to add to quoteattestation API.